### PR TITLE
fix crash when erroneously using "take" in room without NPC

### DIFF
--- a/lib/adventure_game.rb
+++ b/lib/adventure_game.rb
@@ -168,7 +168,7 @@ require 'pry'
 
     # use with NPCs
     def take(item)
-      if current_room.npc.has_item(item)
+      if current_room.npc && current_room.npc.has_item(item)
         @player.add_to_inventory(item)
       else
         puts "Sorry, that item isn't here."


### PR DESCRIPTION
The "take" command is for taking items from NPCs, but unwary players
might accidentally use it when trying to pick up an unattended
item. This led the program to terminate with an unrescued NoMethodError:

```
What now?
look around
HOLY CRAP THERE'S A BEAR IN THIS ROOM.
This room contains a canister of bear repellant
What now?
take a canister of bear repellant
lib/adventure_game.rb:171:in `take': undefined method `has_item' for
nil:NilClass (NoMethodError)
             from lib/adventure_game.rb:228:in `parse_choice'
             from lib/adventure_game.rb:152:in `play'
             from lib/adventure_game.rb:142:in `initialize'
             from lib/adventure_game.rb:480:in `new'
             from lib/adventure_game.rb:480:in `<main>'
```

By inserting a check that `current_room.npc` is not `nil`, we can
instead continue play.